### PR TITLE
增加微信支付“下载对账单”

### DIFF
--- a/src/main/java/com/lly835/bestpay/model/DownloadBillRequest.java
+++ b/src/main/java/com/lly835/bestpay/model/DownloadBillRequest.java
@@ -1,0 +1,14 @@
+package com.lly835.bestpay.model;
+
+import lombok.Data;
+
+/**
+ * 下载对账文件请求
+ */
+@Data
+public class DownloadBillRequest {
+
+    //对账日期
+    private String billDate;
+
+}

--- a/src/main/java/com/lly835/bestpay/model/wxpay/WxPayApi.java
+++ b/src/main/java/com/lly835/bestpay/model/wxpay/WxPayApi.java
@@ -5,6 +5,7 @@ import com.lly835.bestpay.model.wxpay.response.WxRefundResponse;
 import com.lly835.bestpay.model.wxpay.response.WxPaySandboxKeyResponse;
 import com.lly835.bestpay.model.wxpay.response.WxPaySyncResponse;
 import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
@@ -48,5 +49,5 @@ public interface WxPayApi {
     Call<WxOrderQueryResponse> orderquery(@Body RequestBody body);
 
     @POST("/pay/downloadbill")
-    Call<String> downloadBill(@Body RequestBody body);
+    Call<ResponseBody> downloadBill(@Body RequestBody body);
 }

--- a/src/main/java/com/lly835/bestpay/model/wxpay/WxPayApi.java
+++ b/src/main/java/com/lly835/bestpay/model/wxpay/WxPayApi.java
@@ -46,4 +46,7 @@ public interface WxPayApi {
      */
     @POST("/pay/orderquery")
     Call<WxOrderQueryResponse> orderquery(@Body RequestBody body);
+
+    @POST("/pay/downloadbill")
+    Call<String> downloadBill(@Body RequestBody body);
 }

--- a/src/main/java/com/lly835/bestpay/model/wxpay/request/WxDownloadBillRequest.java
+++ b/src/main/java/com/lly835/bestpay/model/wxpay/request/WxDownloadBillRequest.java
@@ -1,0 +1,43 @@
+package com.lly835.bestpay.model.wxpay.request;
+
+import lombok.Data;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+/**
+ * Created by steven ma
+ * 2019-03-15 11:49
+ */
+@Data
+@Root(name = "xml", strict = false)
+public class WxDownloadBillRequest {
+
+    //公众账号ID
+    @Element(name = "appid")
+    private String appid;
+
+    //商户号
+    @Element(name = "mch_id")
+    private String mchId;
+
+    //随机字符串
+    @Element(name = "nonce_str")
+    private String nonceStr;
+
+    //签名
+    @Element(name = "sign")
+    private String sign;
+
+    //对账单日期
+    @Element(name = "bill_date")
+    private String billDate;
+
+    //账单类型
+    @Element(name = "bill_type", required = false)
+    private String billType = "ALL";
+
+//    //压缩账单
+//    @Element(name = "tar_type", required = false)
+//    private String tarType = "GZIP";
+
+}

--- a/src/main/java/com/lly835/bestpay/model/wxpay/response/WxDownloadBillResponse.java
+++ b/src/main/java/com/lly835/bestpay/model/wxpay/response/WxDownloadBillResponse.java
@@ -1,0 +1,24 @@
+package com.lly835.bestpay.model.wxpay.response;
+
+import lombok.Data;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+/**
+ * 下载对账文件返回-只有发生错误的时候才会返回
+ * Created by steven ma
+ * 2019/3/20 16:48
+ */
+@Data
+@Root(name = "xml", strict = false)
+public class WxDownloadBillResponse {
+
+    @Element(name = "return_code")
+    private String returnCode;
+
+    @Element(name = "return_msg", required = false)
+    private String returnMsg;
+
+    @Element(name = "error_code")
+    private String errorCode;
+}

--- a/src/main/java/com/lly835/bestpay/service/BestPayService.java
+++ b/src/main/java/com/lly835/bestpay/service/BestPayService.java
@@ -1,12 +1,7 @@
 package com.lly835.bestpay.service;
 
 import com.lly835.bestpay.config.SignType;
-import com.lly835.bestpay.model.OrderQueryRequest;
-import com.lly835.bestpay.model.OrderQueryResponse;
-import com.lly835.bestpay.model.PayRequest;
-import com.lly835.bestpay.model.PayResponse;
-import com.lly835.bestpay.model.RefundRequest;
-import com.lly835.bestpay.model.RefundResponse;
+import com.lly835.bestpay.model.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -59,4 +54,12 @@ public interface BestPayService {
      * @return
      */
     OrderQueryResponse query(OrderQueryRequest request);
+
+
+    /**
+     * 下载对账单
+     * @param request
+     * @return
+     */
+    String downloadBill(DownloadBillRequest request);
 }

--- a/src/main/java/com/lly835/bestpay/service/impl/BestPayServiceImpl.java
+++ b/src/main/java/com/lly835/bestpay/service/impl/BestPayServiceImpl.java
@@ -5,12 +5,7 @@ import com.lly835.bestpay.config.WxPayH5Config;
 import com.lly835.bestpay.enums.BestPayResultEnum;
 import com.lly835.bestpay.enums.BestPayTypeEnum;
 import com.lly835.bestpay.exception.BestPayException;
-import com.lly835.bestpay.model.OrderQueryRequest;
-import com.lly835.bestpay.model.OrderQueryResponse;
-import com.lly835.bestpay.model.PayRequest;
-import com.lly835.bestpay.model.PayResponse;
-import com.lly835.bestpay.model.RefundRequest;
-import com.lly835.bestpay.model.RefundResponse;
+import com.lly835.bestpay.model.*;
 import com.lly835.bestpay.service.BestPayService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -109,5 +104,15 @@ public class BestPayServiceImpl implements BestPayService {
         wxPayService.setWxPayH5Config(this.wxPayH5Config);
 
         return wxPayService.query(request);
+    }
+
+    @Override
+    public String downloadBill(DownloadBillRequest request) {
+
+        WxPayServiceImpl wxPayService = new WxPayServiceImpl();
+        wxPayService.setWxPayH5Config(this.wxPayH5Config);
+
+
+        return wxPayService.downloadBill(request);
     }
 }

--- a/src/main/java/com/lly835/bestpay/service/impl/WxPayServiceImpl.java
+++ b/src/main/java/com/lly835/bestpay/service/impl/WxPayServiceImpl.java
@@ -11,10 +11,7 @@ import com.lly835.bestpay.model.wxpay.request.WxDownloadBillRequest;
 import com.lly835.bestpay.model.wxpay.request.WxOrderQueryRequest;
 import com.lly835.bestpay.model.wxpay.request.WxPayRefundRequest;
 import com.lly835.bestpay.model.wxpay.request.WxPayUnifiedorderRequest;
-import com.lly835.bestpay.model.wxpay.response.WxOrderQueryResponse;
-import com.lly835.bestpay.model.wxpay.response.WxPayAsyncResponse;
-import com.lly835.bestpay.model.wxpay.response.WxPaySyncResponse;
-import com.lly835.bestpay.model.wxpay.response.WxRefundResponse;
+import com.lly835.bestpay.model.wxpay.response.*;
 import com.lly835.bestpay.utils.MapUtil;
 import com.lly835.bestpay.utils.MoneyUtil;
 import com.lly835.bestpay.utils.RandomUtil;
@@ -337,6 +334,16 @@ public class WxPayServiceImpl extends BestPayServiceImpl {
         String response = null;
         try {
             response = retrofitResponse.body().string();
+
+            //如果返回xml格式，表示返回异常
+            if(response.startsWith("<")) {
+                WxDownloadBillResponse downloadBillResponse =  (WxDownloadBillResponse)XmlUtil.toObject(response,
+                        WxDownloadBillResponse.class);
+                throw new RuntimeException("【对账文件】返回异常 错误码: " +
+                        downloadBillResponse.getErrorCode() +
+                        " 错误信息: " + downloadBillResponse.getReturnMsg());
+            }
+
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/lly835/bestpay/service/impl/WxPayServiceImpl.java
+++ b/src/main/java/com/lly835/bestpay/service/impl/WxPayServiceImpl.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Call;
 import retrofit2.Response;
@@ -321,8 +322,8 @@ public class WxPayServiceImpl extends BestPayServiceImpl {
         wxRequest.setSign(WxPaySignature.sign(MapUtil.buildMap(wxRequest), wxPayH5Config.getMchKey()));
         RequestBody body = RequestBody.create(MediaType.parse("application/xml; charset=utf-8"), XmlUtil.toString(wxRequest));
 
-        Call<String> call = retrofit.create(WxPayApi.class).downloadBill(body);
-        Response<String> retrofitResponse  = null;
+        Call<ResponseBody> call = retrofit.create(WxPayApi.class).downloadBill(body);
+        Response<ResponseBody> retrofitResponse  = null;
         try{
             retrofitResponse = call.execute();
         }catch (IOException e) {
@@ -333,7 +334,12 @@ public class WxPayServiceImpl extends BestPayServiceImpl {
             throw new RuntimeException("【微信订单查询】网络异常");
         }
 
-        String response = retrofitResponse.body();
+        String response = null;
+        try {
+            response = retrofitResponse.body().string();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
 
         return response;

--- a/src/main/java/com/lly835/bestpay/service/impl/WxPayServiceImpl.java
+++ b/src/main/java/com/lly835/bestpay/service/impl/WxPayServiceImpl.java
@@ -5,13 +5,9 @@ import com.lly835.bestpay.config.WxPayH5Config;
 import com.lly835.bestpay.constants.WxPayConstants;
 import com.lly835.bestpay.enums.BestPayTypeEnum;
 import com.lly835.bestpay.enums.OrderStatusEnum;
-import com.lly835.bestpay.model.OrderQueryRequest;
-import com.lly835.bestpay.model.OrderQueryResponse;
-import com.lly835.bestpay.model.PayRequest;
-import com.lly835.bestpay.model.PayResponse;
-import com.lly835.bestpay.model.RefundRequest;
-import com.lly835.bestpay.model.RefundResponse;
+import com.lly835.bestpay.model.*;
 import com.lly835.bestpay.model.wxpay.WxPayApi;
+import com.lly835.bestpay.model.wxpay.request.WxDownloadBillRequest;
 import com.lly835.bestpay.model.wxpay.request.WxOrderQueryRequest;
 import com.lly835.bestpay.model.wxpay.request.WxPayRefundRequest;
 import com.lly835.bestpay.model.wxpay.request.WxPayUnifiedorderRequest;
@@ -308,4 +304,38 @@ public class WxPayServiceImpl extends BestPayServiceImpl {
         return tradeType;
     }
 
+    /**
+     *
+     * @param request
+     * @return
+     */
+    @Override
+    public String downloadBill(DownloadBillRequest request) {
+
+        WxDownloadBillRequest wxRequest = new WxDownloadBillRequest();
+        wxRequest.setBillDate(request.getBillDate());
+
+        wxRequest.setAppid(wxPayH5Config.getAppId());
+        wxRequest.setMchId(wxPayH5Config.getMchId());
+        wxRequest.setNonceStr(RandomUtil.getRandomStr());
+        wxRequest.setSign(WxPaySignature.sign(MapUtil.buildMap(wxRequest), wxPayH5Config.getMchKey()));
+        RequestBody body = RequestBody.create(MediaType.parse("application/xml; charset=utf-8"), XmlUtil.toString(wxRequest));
+
+        Call<String> call = retrofit.create(WxPayApi.class).downloadBill(body);
+        Response<String> retrofitResponse  = null;
+        try{
+            retrofitResponse = call.execute();
+        }catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        if (!retrofitResponse.isSuccessful()) {
+            throw new RuntimeException("【微信订单查询】网络异常");
+        }
+
+        String response = retrofitResponse.body();
+
+
+        return response;
+    }
 }

--- a/src/test/java/com/lly835/bestpay/WxPayTest.java
+++ b/src/test/java/com/lly835/bestpay/WxPayTest.java
@@ -7,13 +7,14 @@ import com.lly835.bestpay.model.wxpay.response.WxPayAsyncResponse;
 import com.lly835.bestpay.service.impl.BestPayServiceImpl;
 import com.lly835.bestpay.utils.JsonUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.core.Persister;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.charset.Charset;
 import java.util.Random;
 
 /**
@@ -86,13 +87,44 @@ public class WxPayTest {
         log.info(JsonUtil.toJson(response));
     }
 
-    @Test
-    public void downloadBill(){
-        DownloadBillRequest request = new DownloadBillRequest();
-        request.setBillDate("20190319");
+    /**
+     * 解析对账文件示例
+     * @param billFile
+     */
+    private void parseBill(String billFile) throws IOException{
 
-        String response = bestPayService.downloadBill(request);
-        log.info("【对账文件内容】 {}", response);
+        BufferedReader br = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(billFile.getBytes(Charset.forName("utf8"))), Charset.forName("utf8")));
+        String line;
+//        StringBuffer strbuf=new StringBuffer();
+        int count = 0;
+        while ( (line = br.readLine()) != null ) {
+            if(!line.trim().equals("")){
+
+//                strbuf.append(line+"\r\n");
+                log.info("第{}行数据: {}", count + 1, line);
+                count ++;
+            }
+        }
+
+
+    }
+
+    @Test
+    public void downloadBill() throws IOException{
+        DownloadBillRequest request = new DownloadBillRequest();
+        request.setBillDate("20190318");
+
+        try {
+            String response = bestPayService.downloadBill(request);
+            log.info("【对账文件内容】 {}", response);
+
+            //分析对账文件
+            parseBill(response);
+        } catch (RuntimeException e) {
+            log.error("【对账文件获取失败】{}", e.getMessage());
+            Assert.assertNull(e);
+        }
+
     }
 
 }

--- a/src/test/java/com/lly835/bestpay/WxPayTest.java
+++ b/src/test/java/com/lly835/bestpay/WxPayTest.java
@@ -2,12 +2,7 @@ package com.lly835.bestpay;
 
 import com.lly835.bestpay.config.WxPayH5Config;
 import com.lly835.bestpay.enums.BestPayTypeEnum;
-import com.lly835.bestpay.model.OrderQueryRequest;
-import com.lly835.bestpay.model.OrderQueryResponse;
-import com.lly835.bestpay.model.PayRequest;
-import com.lly835.bestpay.model.PayResponse;
-import com.lly835.bestpay.model.RefundRequest;
-import com.lly835.bestpay.model.RefundResponse;
+import com.lly835.bestpay.model.*;
 import com.lly835.bestpay.model.wxpay.response.WxPayAsyncResponse;
 import com.lly835.bestpay.service.impl.BestPayServiceImpl;
 import com.lly835.bestpay.utils.JsonUtil;
@@ -89,6 +84,15 @@ public class WxPayTest {
         request.setOrderId("1528103259255858491");
         OrderQueryResponse response = bestPayService.query(request);
         log.info(JsonUtil.toJson(response));
+    }
+
+    @Test
+    public void downloadBill(){
+        DownloadBillRequest request = new DownloadBillRequest();
+        request.setBillDate("20190319");
+
+        String response = bestPayService.downloadBill(request);
+        log.info("【对账文件内容】 {}", response);
     }
 
 }


### PR DESCRIPTION
增加对微信支付接口“下载对账单”的支持

https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_6

暂时默认：
1. 不采用压缩文件形式
2. 账单类型默认为ALL