### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0"?>
-<project
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>cn.springboot</groupId>
     <artifactId>best-pay-sdk</artifactId>
@@ -78,7 +76,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.1.7
- [CVE-2017-5929](https://www.oscs1024.com/hd/CVE-2017-5929)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.1.7 to 1.2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS