### PR TITLE
fix(sec): upgrade org.apache.tomcat.embed:tomcat-embed-core to 8.5.78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0"?>
-<project
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>cn.springboot</groupId>
     <artifactId>best-pay-sdk</artifactId>
@@ -90,7 +88,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>8.5.50</version>
+            <version>8.5.78</version>
         </dependency>
 
         <!--http client-->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.tomcat.embed:tomcat-embed-core 8.5.50
- [CVE-2020-13934](https://www.oscs1024.com/hd/CVE-2020-13934)


### What did I do？
Upgrade org.apache.tomcat.embed:tomcat-embed-core from 8.5.50 to 8.5.78 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS